### PR TITLE
refactor: enable statistics only in production builds and add the `STAT_ENABLE` env to control the `stat` function

### DIFF
--- a/gadgets/variant-ally/rollup.config.js
+++ b/gadgets/variant-ally/rollup.config.js
@@ -9,7 +9,19 @@ import { join } from 'path';
 import strip from '@rollup/plugin-strip';
 import filesize from 'rollup-plugin-filesize';
 
+/**
+ * @param {string} str
+ */
+function strToBool(str) {
+  return ['false', 'no'].includes(String(str).trim().toLowerCase())
+    ? false
+    : Boolean(str);
+}
+
 const production = process.env.NODE_ENV === 'production';
+const statEnable = process.env.VA_STAT_ENABLE !== undefined
+  ? strToBool(process.env.VA_STAT_ENABLE)
+  : production;
 
 /**
  * Compute a meta hash based on metadata of files inside paths.
@@ -59,6 +71,7 @@ export default defineConfig({
     filesize(),
     replace({
       preventAssignment: true,
+      STAT_ENABLE: statEnable,
       BUILD_HASH: JSON.stringify(computeMetaHash(['src/'])),
     }),
     typescript({

--- a/gadgets/variant-ally/src/env.d.ts
+++ b/gadgets/variant-ally/src/env.d.ts
@@ -6,6 +6,8 @@
 
 const DEBUG: boolean;
 
+const STAT_ENABLE: boolean;
+
 const BUILD_HASH: string;
 
 module 'ext.gadget.VariantAllyDialog';

--- a/gadgets/variant-ally/src/stats.ts
+++ b/gadgets/variant-ally/src/stats.ts
@@ -9,7 +9,9 @@ type StatName =
   | 'variant-prompt-mobile-select';
 
 function stat(name: StatName) {
-  mw.track(`counter.gadget_VariantAlly.${name}`);
+  if (STAT_ENABLE) {
+    mw.track(`counter.gadget_VariantAlly.${name}`);
+  }
 }
 
 export { stat as default, type StatName };


### PR DESCRIPTION
The statistics are completely meaningless for small sites or personal use, and don't seem to need to be present in debug builds. This pr turns off the statistical function of the debug build and provides the STAT_ENABLE env option to force function "stat" to be turned on or off.